### PR TITLE
Bug 1181153: update to use the new treestatus API [DO NOT LAND]

### DIFF
--- a/lib/poller.js
+++ b/lib/poller.js
@@ -3,7 +3,7 @@ const { get } = require("./request");
 const { emit } = require("sdk/event/core");
 const { EventTarget } = require("sdk/event/target");
 const { setTimeout, clearTimeout } = require("sdk/timers");
-const URL = "https://treestatus.mozilla.org/?format=json";
+const URL = "https://api.pub.build.mozilla.org/treestatus/trees";
 
 let target = module.exports = EventTarget();
 let timeout = null;
@@ -18,7 +18,7 @@ function poll () {
   }
 
   get(URL).then(json => {
-    let data = json && json[Prefs.prefs.tree];
+    let data = json && json.result[Prefs.prefs.tree];
     if (data) {
       emit(target, "data", data);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,6 @@ function getIcon (status) {
 exports.getIcon = getIcon;
 
 function getURL () {
-  return `https://treestatus.mozilla.org/${Prefs.prefs.tree}`;
+  return `https://api.pub.build.mozilla.org/treestatus/details/${Prefs.prefs.tree}`;
 }
 exports.getURL = getURL;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "type": "bool",
     "name": "notify"
   }, {
-    "description": "Which tree from https://treestatus.mozilla.org to monitor.",
+    "description": "Which tree from https://api.pub.build.mozilla.org/treestatus to monitor.",
     "title": "Tree to Observe",
     "value": "fx-team",
     "type": "menulist",


### PR DESCRIPTION
Untested, but a fairly straightforward change: URL changes, and the new API returns all results wrapped in an object with a "result" key.

Please don't land (well, don't _ship_) this until bug 1181153 gets deployed.

BTW, the `/treestatus/trees/{treename}` endpoint is heavily cached and meant to be polled.  I didn't try to fix that here, but if this extension is popular then that might help reduce unnecessary load.
